### PR TITLE
Fix failure to share under rails4, due to missing json root element

### DIFF
--- a/lib/socialcast/message.rb
+++ b/lib/socialcast/message.rb
@@ -1,5 +1,7 @@
 require 'active_resource'
 
+ActiveResource::Base.include_root_in_json = true
+
 module Socialcast
   class Message < ActiveResource::Base
     headers['Accept'] = 'application/json'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,8 +7,7 @@ describe Socialcast::CLI do
       before do
         Socialcast.stub(:credentials).and_return(YAML.load_file(File.join(File.dirname(__FILE__), 'fixtures', 'credentials.yml')))
         stub_request(:post, "https://ryan%40socialcast.com:foo@test.staging.socialcast.com/api/messages.json").
-                 with(:body => /message\_type\"\:null/).
-                 with(:body => /testing/).
+                 with(:body => { "message" => { "body" => "testing", "url" => nil, "message_type" => nil, "attachment_ids" => [], "group_id" => nil }}).
                  with(:headers => {'Accept' => 'application/json'}).
                  to_return(:status => 200, :body => "", :headers => {})
 


### PR DESCRIPTION
Add spec, and fix root element no longer being in the json under rails4.
