### PR TITLE
using the options domain variable to detect the community domain

### DIFF
--- a/lib/socialcast/command_line/cli.rb
+++ b/lib/socialcast/command_line/cli.rb
@@ -53,7 +53,7 @@ module Socialcast
         params = { :email => user, :password => password }
         response = Socialcast::CommandLine::Authenticate.new(:user, options, params).request
         communities = JSON.parse(response.body.to_s)['communities']
-        domain = communities.detect {|c| c['domain'] == domain} ? domain : communities.first['domain']
+        domain = communities.detect { |c| c['domain'] == options[:domain] } ? options[:domain] : communities.first['domain']
 
         Socialcast::CommandLine.credentials = {
           :user => user,

--- a/lib/socialcast/command_line/version.rb
+++ b/lib/socialcast/command_line/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module CommandLine
-    VERSION = "1.3.10"
+    VERSION = "1.3.11"
   end
 end


### PR DESCRIPTION
When authenticating and passing a domain it never actually used the domain they passed in as it was referencing a non-existing domain variable.
