### PR TITLE
fix boolean argument warning from thor 0.19.4

### DIFF
--- a/lib/socialcast/command_line/cli.rb
+++ b/lib/socialcast/command_line/cli.rb
@@ -127,6 +127,7 @@ module Socialcast
       method_option :force_sync, :type => :boolean, :aliases => '-f', :desc => 'Pushes all photos from LDAP to socialcast'
       def sync_photos
         config = ldap_config options
+
         Socialcast::CommandLine::ProvisionPhoto.new(config, options).sync
       end
 

--- a/lib/socialcast/command_line/cli.rb
+++ b/lib/socialcast/command_line/cli.rb
@@ -124,10 +124,9 @@ module Socialcast
 
       desc 'sync_photos', 'Upload default avatar photos from LDAP repository'
       method_option :config, :default => 'ldap.yml', :aliases => '-c'
-      method_option :force_sync, :default => false, :aliases => '-f', :desc => 'Pushes all photos from LDAP to socialcast'
+      method_option :force_sync, :type => :boolean, :aliases => '-f', :desc => 'Pushes all photos from LDAP to socialcast'
       def sync_photos
         config = ldap_config options
-
         Socialcast::CommandLine::ProvisionPhoto.new(config, options).sync
       end
 

--- a/lib/socialcast/command_line/version.rb
+++ b/lib/socialcast/command_line/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module CommandLine
-    VERSION = '1.4.0'
+    VERSION = '1.4.1'
   end
 end


### PR DESCRIPTION
Fix this warning coming out of recent versions of thor, by declaring `force_sync` to be of boolean type:
```
Expected string default value for '--force-sync'; got false (boolean)
```

