### PR TITLE
Use net ldap

### DIFF
--- a/lib/net_ldap_patches/connection/next_msgid.rb
+++ b/lib/net_ldap_patches/connection/next_msgid.rb
@@ -1,0 +1,16 @@
+module NetLDAPPatches
+  module Connection
+    module NextMsgid
+      INITIAL_MSGID_ENV_VAR = 'NET_LDAP_INITIAL_MSGID'
+      def next_msgid
+        # avoids using the msgid range 128-255 by starting the msgid counter at 300
+        # otherwise certain versions and/or configurations of Microsoft's Active Directory will
+        # return Error Searching: invalid response-type in search: 24 and halt the mirroring process
+        @msgid ||= ENV.key?(INITIAL_MSGID_ENV_VAR) ? ENV[INITIAL_MSGID_ENV_VAR].to_i : 300
+        @msgid += 1
+      end
+    end
+  end
+end
+
+Net::LDAP::Connection.prepend NetLDAPPatches::Connection::NextMsgid

--- a/lib/net_ldap_patches/connection/next_msgid.rb
+++ b/lib/net_ldap_patches/connection/next_msgid.rb
@@ -1,4 +1,4 @@
-module NetLDAPPatches
+module NetLdapPatches
   module Connection
     module NextMsgid
       INITIAL_MSGID_ENV_VAR = 'NET_LDAP_INITIAL_MSGID'
@@ -13,4 +13,4 @@ module NetLDAPPatches
   end
 end
 
-Net::LDAP::Connection.prepend NetLDAPPatches::Connection::NextMsgid
+Net::LDAP::Connection.prepend NetLdapPatches::Connection::NextMsgid

--- a/lib/socialcast.rb
+++ b/lib/socialcast.rb
@@ -9,6 +9,7 @@ require_relative 'socialcast/command_line/provision_photo'
 require_relative 'socialcast/command_line/message'
 require_relative 'socialcast/command_line/cli'
 require_relative 'socialcast/command_line/version'
+require_relative 'net_ldap_patches/connection/next_msgid'
 
 module Socialcast
   module CommandLine

--- a/lib/socialcast/command_line/version.rb
+++ b/lib/socialcast/command_line/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module CommandLine
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
   end
 end

--- a/socialcast.gemspec
+++ b/socialcast.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.4', '>= 1.4.6'
   s.add_runtime_dependency 'thor', '~> 0.14', '>= 0.14.6'
   s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.2'
-  s.add_runtime_dependency 'socialcast-net-ldap', '~> 0.1', '>= 0.1.6'
+  s.add_runtime_dependency 'net-ldap', '~> 0.15', '>= 0.15.0'
   s.add_runtime_dependency 'activesupport', '>= 4.0'
   s.add_runtime_dependency 'builder', '~> 3.1'
   s.add_development_dependency 'rspec', '~> 3.3'

--- a/spec/net_ldap_patches/connection/next_msgid_spec.rb
+++ b/spec/net_ldap_patches/connection/next_msgid_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe NetLDAPPatches::Connection::NextMsgid do
+  describe '#next_msgid' do
+    context 'when ENV["NET_LDAP_INITIAL_MSGID"] is not present' do
+      it { expect(Net::LDAP::Connection.new.next_msgid).to eq 301 }
+    end
+    context 'when ENV["NET_LDAP_INITIAL_MSGID"] is present' do
+      before { ENV['NET_LDAP_INITIAL_MSGID'] = '5' }
+      after { ENV.delete 'NET_LDAP_INITIAL_MSGID' }
+      it { expect(Net::LDAP::Connection.new.next_msgid).to eq 6 }
+    end
+  end
+end

--- a/spec/net_ldap_patches/connection/next_msgid_spec.rb
+++ b/spec/net_ldap_patches/connection/next_msgid_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe NetLDAPPatches::Connection::NextMsgid do
+describe NetLdapPatches::Connection::NextMsgid do
   describe '#next_msgid' do
     context 'when ENV["NET_LDAP_INITIAL_MSGID"] is not present' do
       it { expect(Net::LDAP::Connection.new.next_msgid).to eq 301 }


### PR DESCRIPTION
Update to use the latest version of the upstream `net-ldap` library, rather than the [outdated socialcast fork](https://github.com/socialcast/ruby-net-ldap).